### PR TITLE
generated codemeta.json

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@ man-roxygen
 ^cran-comments\.md$
 inst/cache
 .github
+^codemeta\.json$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Version: 0.1.5.9110
 Authors@R: c(person("Scott", "Chamberlain",
     role = c("aut", "cre"),
     email = "myrmecocystus+r@gmail.com",
-    comment = c(ORCID = "orcid.org/0000-0003-1444-9135")))
+    comment = c(ORCID = "0000-0003-1444-9135")))
 License: MIT + file LICENSE
 URL: https://github.com/ropensci/crminer
 BugReports: https://github.com/ropensci/crminer/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,8 +6,10 @@ Description: Text mining client for 'Crossref' (<https://crossref.org>). Include
     text articles from those links or Digital Object Identifiers ('DOIs'),
     and text extraction from 'PDFs'.
 Version: 0.1.5.9110
-Authors@R: c(person("Scott", "Chamberlain", role = c("aut", "cre"),
-    email = "myrmecocystus+r@gmail.com"))
+Authors@R: c(person("Scott", "Chamberlain",
+    role = c("aut", "cre"),
+    email = "myrmecocystus+r@gmail.com",
+    comment = c(ORCID = "orcid.org/0000-0003-1444-9135")))
 License: MIT + file LICENSE
 URL: https://github.com/ropensci/crminer
 BugReports: https://github.com/ropensci/crminer/issues
@@ -24,3 +26,6 @@ Suggests:
     rcrossref,
     testthat
 RoxygenNote: 6.0.1
+X-schema.org-applicationCategory: Literature
+X-schema.org-keywords: text-mining, literature, publications, crossref, pdf, xml
+X-schema.org-isPartOf: https://ropensci.org

--- a/codemeta.json
+++ b/codemeta.json
@@ -31,7 +31,7 @@
       "givenName": "Scott",
       "familyName": "Chamberlain",
       "email": "myrmecocystus+r@gmail.com",
-      "@id": "orcid.org/0000-0003-1444-9135"
+      "@id": "http://orcid.org/0000-0003-1444-9135"
     }
   ],
   "maintainer": {
@@ -39,7 +39,7 @@
     "givenName": "Scott",
     "familyName": "Chamberlain",
     "email": "myrmecocystus+r@gmail.com",
-    "@id": "orcid.org/0000-0003-1444-9135"
+    "@id": "http://orcid.org/0000-0003-1444-9135"
   },
   "softwareSuggestions": [
     {
@@ -153,5 +153,5 @@
   "developmentStatus": "active",
   "releaseNotes": "https://github.com/ropensci/crminer/blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/crminer/blob/master/README.md",
-  "fileSize": "2917.001KB"
+  "fileSize": "2917.007KB"
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,157 @@
+{
+  "@context": [
+    "https://doi.org/doi:10.5063/schema/codemeta-2.0",
+    "http://schema.org"
+  ],
+  "@type": "SoftwareSourceCode",
+  "identifier": "crminer",
+  "description":
+    "Text mining client for 'Crossref' (<https://crossref.org>). Includes\n    functions for getting getting links to full text of articles, fetching full\n    text articles from those links or Digital Object Identifiers ('DOIs'),\n    and text extraction from 'PDFs'.",
+  "name": "crminer: Fetch 'Scholary' Full Text from 'Crossref'",
+  "codeRepository": "https://github.com/ropensci/crminer",
+  "issueTracker": "https://github.com/ropensci/crminer/issues",
+  "license": "https://spdx.org/licenses/MIT",
+  "version": "0.1.5.9110",
+  "programmingLanguage": {
+    "@type": "ComputerLanguage",
+    "name": "R",
+    "version": "3.4.2",
+    "url": "https://r-project.org"
+  },
+  "runtimePlatform": "R version 3.4.2 (2017-09-28)",
+  "provider": {
+    "@id": "https://cran.r-project.org",
+    "@type": "Organization",
+    "name": "Central R Archive Network (CRAN)",
+    "url": "https://cran.r-project.org"
+  },
+  "author": [
+    {
+      "@type": "Person",
+      "givenName": "Scott",
+      "familyName": "Chamberlain",
+      "email": "myrmecocystus+r@gmail.com",
+      "@id": "orcid.org/0000-0003-1444-9135"
+    }
+  ],
+  "maintainer": {
+    "@type": "Person",
+    "givenName": "Scott",
+    "familyName": "Chamberlain",
+    "email": "myrmecocystus+r@gmail.com",
+    "@id": "orcid.org/0000-0003-1444-9135"
+  },
+  "softwareSuggestions": [
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "roxygen2",
+      "name": "roxygen2",
+      "version": "6.0.1",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "rcrossref",
+      "name": "rcrossref",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "testthat",
+      "name": "testthat",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    }
+  ],
+  "softwareRequirements": [
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "crul",
+      "name": "crul",
+      "version": "0.3.4",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "jsonlite",
+      "name": "jsonlite",
+      "version": "1.4",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "xml2",
+      "name": "xml2",
+      "version": "1.1.0",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "pdftools",
+      "name": "pdftools",
+      "version": "1.2",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "hoardr",
+      "name": "hoardr",
+      "version": "0.2.0",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Central R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      }
+    }
+  ],
+  "applicationCategory": "Literature",
+  "isPartOf": "https://ropensci.org",
+  "keywords": [
+    "text-mining",
+    "literature",
+    "publications",
+    "crossref",
+    "pdf",
+    "xml"
+  ],
+  "contIntegration": "https://travis-ci.org/ropensci/crminer",
+  "developmentStatus": "active",
+  "releaseNotes": "https://github.com/ropensci/crminer/blob/master/NEWS.md",
+  "readme": "https://github.com/ropensci/crminer/blob/master/README.md",
+  "fileSize": "2917.001KB"
+}


### PR DESCRIPTION
I'm an intern with ropensci working with @sckott and @cboettig to improve package metadata in the ropensci suite. For this package, I've added applicationCategory and keywords (as advised by Scott Chamberlain) to the DESCRIPTION file. Re-generated codemeta.json file from updated DESCRIPTION by running write_codemeta()