### PR TITLE
Fix http/https string substitution when crawling full text links from Elsevier

### DIFF
--- a/R/crm_links.R
+++ b/R/crm_links.R
@@ -29,9 +29,9 @@
 #' custom fix in this function for that publisher. Anyway, expect changes...
 #'
 #' @return `NULL` if no full text links given; a list of tdmurl objects if
-#' links found. a tdmurl object is an S3 class wrapped around a simple list,
+#' links found. a tdmurl object is an S3 class wrapped around a simple list, 
 #' with attributes for:
-#'
+#' 
 #' - type: type, matchin type passed to the function
 #' - doi: DOI
 #' - member: Crossref member ID

--- a/R/crm_links.R
+++ b/R/crm_links.R
@@ -106,7 +106,7 @@ crm_links <- function(doi, type = 'all', ...) {
         })
       } else {
         y <- match.arg(type, c('xml', 'plain', 'html', 'pdf', 'unspecified'))
-        makeurl(x = withtype[[y]]$URL, y = y, z = doi, res$member,
+        makeurl(x = withtype[[y]]$URL, y = y, z = doi, res$member, 
           withtype[[y]]$`intended-application`)
       }
     }

--- a/R/crm_links.R
+++ b/R/crm_links.R
@@ -29,9 +29,9 @@
 #' custom fix in this function for that publisher. Anyway, expect changes...
 #'
 #' @return `NULL` if no full text links given; a list of tdmurl objects if
-#' links found. a tdmurl object is an S3 class wrapped around a simple list, 
+#' links found. a tdmurl object is an S3 class wrapped around a simple list,
 #' with attributes for:
-#' 
+#'
 #' - type: type, matchin type passed to the function
 #' - doi: DOI
 #' - member: Crossref member ID
@@ -95,7 +95,7 @@ crm_links <- function(doi, type = 'all', ...) {
 
       if (basename(res$member) == "78") {
         withtype <- lapply(withtype, function(z) {
-          z$URL <- sub("http", "https", z$URL)
+          z$URL <- sub("http://", "https://", z$URL)
           z
         })
       }
@@ -106,7 +106,7 @@ crm_links <- function(doi, type = 'all', ...) {
         })
       } else {
         y <- match.arg(type, c('xml', 'plain', 'html', 'pdf', 'unspecified'))
-        makeurl(x = withtype[[y]]$URL, y = y, z = doi, res$member, 
+        makeurl(x = withtype[[y]]$URL, y = y, z = doi, res$member,
           withtype[[y]]$`intended-application`)
       }
     }

--- a/tests/testthat/test-crm_plain.R
+++ b/tests/testthat/test-crm_plain.R
@@ -38,6 +38,7 @@ test_that("crm_plain works with character URL input", {
 
 test_that("crm_plain fails well",{
   skip_on_cran()
+
   expect_error(crm_plain(5), "no 'crm_plain' method for numeric")
   expect_error(crm_plain(mtcars), "no 'crm_plain' method for data.frame")
   expect_error(crm_plain(matrix(1:5)), "no 'crm_plain' method for matrix")

--- a/tests/testthat/test-crm_plain.R
+++ b/tests/testthat/test-crm_plain.R
@@ -38,7 +38,7 @@ test_that("crm_plain works with character URL input", {
 
 test_that("crm_plain fails well",{
   skip_on_cran()
-
+  
   expect_error(crm_plain(5), "no 'crm_plain' method for numeric")
   expect_error(crm_plain(mtcars), "no 'crm_plain' method for data.frame")
   expect_error(crm_plain(matrix(1:5)), "no 'crm_plain' method for matrix")

--- a/tests/testthat/test-crm_plain.R
+++ b/tests/testthat/test-crm_plain.R
@@ -38,7 +38,6 @@ test_that("crm_plain works with character URL input", {
 
 test_that("crm_plain fails well",{
   skip_on_cran()
-
   expect_error(crm_plain(5), "no 'crm_plain' method for numeric")
   expect_error(crm_plain(mtcars), "no 'crm_plain' method for data.frame")
   expect_error(crm_plain(matrix(1:5)), "no 'crm_plain' method for matrix")

--- a/tests/testthat/test-crm_plain.R
+++ b/tests/testthat/test-crm_plain.R
@@ -5,6 +5,7 @@ title <- "On the unitarity of linearized General Relativity coupled to matter"
 
 if (identical(Sys.getenv("NOT_CRAN"), "true")) {
   link1 <- crm_links("10.1016/j.physletb.2010.10.049", "plain")
+  link2 <- crm_links("10.1016/j.scib.2017.04.011", "plain")
 }
 
 test_that("crm_plain works with links input",{
@@ -15,6 +16,15 @@ test_that("crm_plain works with links input",{
   expect_is(res, "character")
   expect_gt(nchar(res), 100000L)
   expect_match(res, title)
+})
+
+test_that("crm_plain works with Elsevier input",{
+  skip_on_cran()
+  skip_on_travis()
+
+  res <- suppressMessages(crm_plain(link2))
+  expect_is(res, "character")
+  expect_gt(nchar(res), 100L)
 })
 
 test_that("crm_plain works with character URL input", {
@@ -28,7 +38,7 @@ test_that("crm_plain works with character URL input", {
 
 test_that("crm_plain fails well",{
   skip_on_cran()
-  
+
   expect_error(crm_plain(5), "no 'crm_plain' method for numeric")
   expect_error(crm_plain(mtcars), "no 'crm_plain' method for data.frame")
   expect_error(crm_plain(matrix(1:5)), "no 'crm_plain' method for matrix")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Hi @sckott , while sending some Elsevier DOIs to Crossref using `crminer::crm_links`, malformed full-text urls starting with `httpss` instead of `https` were returned:

```r
crminer::crm_links("10.1016/j.scib.2017.04.011") 
$xml
<url> httpss://api.elsevier.com/content/article/PII:S2095927317301925?httpAccept=text/xml

$plain
<url> httpss://api.elsevier.com/content/article/PII:S2095927317301925?httpAccept=text/plain
```

This little fix should address the issue.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
